### PR TITLE
visionipc:  fix assert in getAvailableStreams

### DIFF
--- a/visionipc/visionipc_client.cc
+++ b/visionipc/visionipc_client.cc
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <chrono>
 #include <cassert>
 #include <iostream>


### PR DESCRIPTION
the vipc client still can connect to the ipc path even if the camerad is not running.   This could be due to the camerad not shutting down properly and the ipc path not being removed.

`ipc_sendrecv_with_fds` will returns -1 In this case. this causes the following assertion to fail.

> ui: cereal/visionipc/visionipc_client.cc:133: static std::set<VisionStreamType> VisionIpcClient::getAvailableStreams(const std::string &, bool): Assertion `(r >= 0) && (r % sizeof(VisionStreamType) == 0)' failed.


This bug can be reproduced by clicking “preview driver camera" button quickly and continuously in the UI interface.