### PR TITLE
msgq: refactor blocking recv for improved robustness and performance

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -15,7 +15,7 @@ msgq_objects = env.SharedObject([
   'msgq/msgq.cc',
 ])
 msgq = env.Library('msgq', msgq_objects)
-msgq_python = envCython.Program('msgq/ipc_pyx.so', 'msgq/ipc_pyx.pyx', LIBS=envCython["LIBS"]+[msgq, "zmq", common])
+msgq_python = envCython.Program('msgq/ipc_pyx.so', 'msgq/ipc_pyx.pyx', LIBS=envCython["LIBS"]+[msgq, "zmq", 'pthread', common])
 
 # Build Vision IPC
 vipc_files = ['visionipc.cc', 'visionipc_server.cc', 'visionipc_client.cc', 'visionbuf.cc']
@@ -31,7 +31,7 @@ visionipc = env.Library('visionipc', vipc_objects)
 
 
 vipc_frameworks = []
-vipc_libs = envCython["LIBS"] + [visionipc, msgq, common, "zmq"]
+vipc_libs = envCython["LIBS"] + [visionipc, msgq, common, "zmq", 'pthread']
 if arch == "Darwin":
   vipc_frameworks.append('OpenCL')
 else:
@@ -45,4 +45,5 @@ if GetOption('extras'):
              [f'{visionipc_dir.abspath}/test_runner.cc', f'{visionipc_dir.abspath}/visionipc_tests.cc'],
               LIBS=['pthread'] + vipc_libs, FRAMEWORKS=vipc_frameworks)
 
+msgq = [msgq, 'pthread']
 Export('visionipc', 'msgq', 'msgq_python')

--- a/msgq/impl_msgq.cc
+++ b/msgq/impl_msgq.cc
@@ -72,7 +72,7 @@ Message *MSGQSubSocket::receive(bool non_blocking) {
     sigemptyset(&mask);
     sigaddset(&mask, SIGINT);
     sigaddset(&mask, SIGTERM);
-    sigaddset(&mask, SIGUSR2);
+    sigaddset(&mask, SIGUSR2);  // notification from publisher
 
     pthread_sigmask(SIG_BLOCK, &mask, &old_mask);
 

--- a/msgq/impl_msgq.cc
+++ b/msgq/impl_msgq.cc
@@ -76,14 +76,14 @@ Message *MSGQSubSocket::receive(bool non_blocking) {
 
     pthread_sigmask(SIG_BLOCK, &mask, &old_mask);
 
-    int64_t timieout_ns = ((timeout != -1) ? timeout : 100) * 1000000;
+    int64_t timeout_ns = ((timeout != -1) ? timeout : 100) * 1000000;
     auto start = steady_clock::now();
 
     // Continue receiving messages until timeout or interruption by SIGINT or SIGTERM
-    while (rc == 0 && timieout_ns > 0) {
+    while (rc == 0 && timeout_ns > 0) {
       struct timespec ts {
-        timieout_ns / 1000000000,
-        timieout_ns % 1000000000,
+        timeout_ns / 1000000000,
+        timeout_ns % 1000000000,
       };
 
       int ret = sigtimedwait(&mask, nullptr, &ts);
@@ -98,7 +98,7 @@ Message *MSGQSubSocket::receive(bool non_blocking) {
       rc = msgq_msg_recv(&msg, q);
 
       if (timeout != -1) {
-        timieout_ns -= duration_cast<nanoseconds>(steady_clock::now() - start).count();
+        timeout_ns -= duration_cast<nanoseconds>(steady_clock::now() - start).count();
         start = steady_clock::now();  // Update start time
       }
     }

--- a/msgq/impl_msgq.cc
+++ b/msgq/impl_msgq.cc
@@ -76,7 +76,7 @@ Message *MSGQSubSocket::receive(bool non_blocking) {
 
     pthread_sigmask(SIG_BLOCK, &mask, &old_mask);
 
-    int64_t timieout_ns = ((timeout != -1) ? timeout : 1000) * 1000000;
+    int64_t timieout_ns = ((timeout != -1) ? timeout : 100) * 1000000;
     auto start = steady_clock::now();
 
     // Continue receiving messages until timeout or interruption by SIGINT or SIGTERM

--- a/msgq/ipc.pxd
+++ b/msgq/ipc.pxd
@@ -50,7 +50,7 @@ cdef extern from "msgq/ipc.h":
     @staticmethod
     SubSocket * create()
     int connect(Context *, string, string, bool)
-    Message * receive(bool)
+    Message * receive(bool) nogil
     void setTimeout(int)
 
   cdef cppclass PubSocket:

--- a/msgq/ipc_pyx.pyx
+++ b/msgq/ipc_pyx.pyx
@@ -196,14 +196,11 @@ cdef class SubSocket:
     self.socket.setTimeout(timeout)
 
   def receive(self, bool non_blocking=False):
-    msg = self.socket.receive(non_blocking)
+    cdef cppMessage *msg
+    with nogil:
+      msg = self.socket.receive(non_blocking)
 
     if msg == NULL:
-      # If a blocking read returns no message check errno if SIGINT was caught in the C++ code
-      if errno.errno == errno.EINTR:
-        print("SIGINT received, exiting")
-        sys.exit(1)
-
       return None
     else:
       sz = msg.getSize()

--- a/msgq/tests/test_messaging.py
+++ b/msgq/tests/test_messaging.py
@@ -74,6 +74,7 @@ class TestPubSubSockets:
   def test_receive_interrupts_on_sigint(self):
     sock = random_sock()
     sub_sock = msgq.sub_sock(sock)
+    sub_sock.setTimeout(1000)
 
     # Send SIGINT after a short delay
     pid = os.getpid()


### PR DESCRIPTION
Replaced the previous method of installing, saving, and restoring signal handlers with a more streamlined and standard approach using signal masks (**pthread_sigmask**, **sigtimedwait**) for blocking receive operations. This update enhances the consistency and reliability of signal handling, aligning with best practices. It also removes the need for `msgq_poll`, thereby improving the efficiency of the receive function.

Additionally, a new test case, `test_receive_interrupts_on_sigint`, has been added to confirm and verify the functionality of the updated signal handling.

Since signal blocking is now managed in the C++ code, `nogil` is used in the Cython code to ensure the GIL is released during the execution of the receive function. This prevents it from impacting other Python threads.