### PR TITLE
msgq: use shared memory mutex and condition variables for synchronization

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -15,7 +15,7 @@ msgq_objects = env.SharedObject([
   'msgq/msgq.cc',
 ])
 msgq = env.Library('msgq', msgq_objects)
-msgq_python = envCython.Program('msgq/ipc_pyx.so', 'msgq/ipc_pyx.pyx', LIBS=envCython["LIBS"]+[msgq, "zmq", common])
+msgq_python = envCython.Program('msgq/ipc_pyx.so', 'msgq/ipc_pyx.pyx', LIBS=envCython["LIBS"]+[msgq, "zmq", common, 'pthread'])
 
 # Build Vision IPC
 vipc_files = ['visionipc.cc', 'visionipc_server.cc', 'visionipc_client.cc', 'visionbuf.cc']
@@ -31,7 +31,7 @@ visionipc = env.Library('visionipc', vipc_objects)
 
 
 vipc_frameworks = []
-vipc_libs = envCython["LIBS"] + [visionipc, msgq, common, "zmq"]
+vipc_libs = envCython["LIBS"] + [visionipc, msgq, common, "zmq", 'pthread']
 if arch == "Darwin":
   vipc_frameworks.append('OpenCL')
 else:
@@ -40,7 +40,7 @@ envCython.Program(f'{visionipc_dir.abspath}/visionipc_pyx.so', f'{visionipc_dir.
                   LIBS=vipc_libs, FRAMEWORKS=vipc_frameworks)
 
 if GetOption('extras'):
-  env.Program('msgq/test_runner', ['msgq/test_runner.cc', 'msgq/msgq_tests.cc'], LIBS=[msgq, common])
+  env.Program('msgq/test_runner', ['msgq/test_runner.cc', 'msgq/msgq_tests.cc'], LIBS=[msgq, common, 'pthread'])
   env.Program(f'{visionipc_dir.abspath}/test_runner',
              [f'{visionipc_dir.abspath}/test_runner.cc', f'{visionipc_dir.abspath}/visionipc_tests.cc'],
               LIBS=['pthread'] + vipc_libs, FRAMEWORKS=vipc_frameworks)

--- a/msgq/msgq.cc
+++ b/msgq/msgq.cc
@@ -74,7 +74,15 @@ void SharedMemory::initMutexCond() {
 }
 
 void SharedMemory::notifyAll() {
+  int ret = pthread_mutex_lock(&(header->mutex));
+#ifndef __APPLE__
+  // Handle case where previous owner of the mutex died
+  if (ret == EOWNERDEAD) {
+    pthread_mutex_consistent((&(header->mutex)));
+  }
+#endif
   pthread_cond_broadcast(&(header->cond));
+  pthread_mutex_unlock(&(header->mutex));
 }
 
 bool SharedMemory::waitFor(int timeout_ms) {

--- a/msgq/msgq.cc
+++ b/msgq/msgq.cc
@@ -1,4 +1,4 @@
-#include "msgq.h"
+#include "msgq/msgq.h"
 
 #include <iostream>
 #include <cassert>


### PR DESCRIPTION
This PR resolve issue #208, enhances the msgq  with shared memory mutexes and condition variables for improved IPC synchronization. While handling signals interrupts all processes, shared memory mechanisms provide a more robust and efficient solution, reducing overhead and complexity in high-frequency event scenarios.

key changes:

Each block of shared memory used for messages now includes a header:
```

struct SharedMemoryHeader {
  pthread_mutex_t mutex;
  pthread_cond_t cond;
  bool initialized;
};
```

This header contains the IPC mutex, condition variable, and an initialization flag.

When sending a message, the corresponding condition variable is used to notify the receiver to retrieve the message.
The Poller uses a global shared memory context, PollerContext, to handle message notifications and reception efficiently.

@pd0wm  If you have a moment, your review of this PR would be greatly appreciated to ensure I haven't missed anything or introduced new issues.