### PR TITLE
use futex for IPC notifications

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -12,6 +12,7 @@ msgq_objects = env.SharedObject([
   'msgq/impl_zmq.cc',
   'msgq/impl_msgq.cc',
   'msgq/impl_fake.cc',
+  'msgq/futex.cc',
   'msgq/msgq.cc',
 ])
 msgq = env.Library('msgq', msgq_objects)

--- a/msgq/futex.cc
+++ b/msgq/futex.cc
@@ -1,0 +1,62 @@
+#include "msgq/futex.h"
+
+#include <fcntl.h>
+#include <limits.h>
+#include <linux/futex.h>
+#include <stdio.h>
+#include <sys/mman.h>
+#include <syscall.h>
+#include <unistd.h>
+
+#include <cassert>
+#include <stdexcept>
+
+Futex::Futex(const std::string &path) {
+  auto fd = open(path.c_str(), O_RDWR | O_CREAT, 0664);
+  if (fd < 0) {
+    throw std::runtime_error("Failed to open file: " + path);
+  }
+
+  if (ftruncate(fd, sizeof(uint32_t)) < 0) {
+    close(fd);
+    throw std::runtime_error("Failed to truncate file: " + path);
+  }
+
+  int *mem = (int *)mmap(NULL, sizeof(uint32_t), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+  close(fd);
+  if (mem == MAP_FAILED) {
+    throw std::runtime_error("Failed to mmap file: " + path);
+  }
+
+  futex = reinterpret_cast<std::atomic<uint32_t> *>(mem);
+}
+
+Futex::~Futex() {
+  munmap(futex, sizeof(uint32_t));
+}
+
+void Futex::broadcast() {
+  // Increment the futex value to signal waiting threads
+  futex->fetch_add(1, std::memory_order_relaxed);
+
+  // Wake up all threads waiting on the futex
+  syscall(SYS_futex, futex, FUTEX_WAKE, INT_MAX, NULL, NULL, 0);
+}
+
+bool Futex::wait(uint32_t expected, int timeout_ms) {
+  if (futex->load(std::memory_order_relaxed) != expected) {
+    return true;  // Already not equal, no need to wait
+  }
+
+  if (timeout_ms <= 0) {
+    return false;  // Timeout immediately
+  }
+
+  // Perform the futex wait syscall
+  struct timespec ts;
+  ts.tv_sec = timeout_ms / 1000;
+  ts.tv_nsec = (timeout_ms % 1000) * 1000 * 1000;
+  syscall(SYS_futex, futex, FUTEX_WAIT, expected, &ts, nullptr, 0);
+
+  return futex->load(std::memory_order_relaxed) != expected;
+}

--- a/msgq/futex.h
+++ b/msgq/futex.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <cstdint>
+#include <atomic>
+#include <string>
+
+
+class Futex {
+public:
+  Futex(const std::string &path);
+  ~Futex();
+  void broadcast();
+  bool wait(uint32_t expected, int timeout_ms);
+  inline uint32_t value() const { return futex->load(); }
+
+private:
+  std::atomic<uint32_t> *futex = nullptr;
+};

--- a/msgq/impl_msgq.cc
+++ b/msgq/impl_msgq.cc
@@ -82,7 +82,6 @@ Message * MSGQSubSocket::receive(bool non_blocking){
   }
 
   msgq_msg_t msg;
-
   MSGQMessage *r = NULL;
 
   int rc = msgq_msg_recv(&msg, q);
@@ -93,20 +92,14 @@ Message * MSGQSubSocket::receive(bool non_blocking){
     items[0].q = q;
 
     int t = (timeout != -1) ? timeout : 100;
-
-    int n = msgq_poll(items, 1, t);
-    rc = msgq_msg_recv(&msg, q);
-
-    // The poll indicated a message was ready, but the receive failed. Try again
-    if (n == 1 && rc == 0){
-      continue;
+    if (msgq_poll(items, 1, t) > 0) {
+      rc = msgq_msg_recv(&msg, q);
     }
 
     if (timeout != -1){
       break;
     }
   }
-
 
   if (!non_blocking){
     std::signal(SIGINT, prev_handler_sigint);


### PR DESCRIPTION
This PR replaces the use of `std::signal `with `futex` for inter-process notifications between publishers and subscribers. improving the robustness and performance of IPC notifications.  Tested on PC and c3x device.

Benefits:

1.  Futex provides a cleaner and more reliable synchronization mechanism than signals. Signals can interrupt system calls across all subscriber processes, adding complexity and impacting overall system performance.
2.  Futex minimizes context switches and eliminates signal handler overhead, thereby reducing synchronization latency. It primarily operates in user space and enters kernel space only when necessary, unlike std::signal, which always involves kernel space operations.
3. Futex provides a more reliable and easier-to-debug synchronization mechanism than signals, ensuring robust inter-process communication.