### PR TITLE
Refactor get_port to use FNV-1a hash for consistency across platforms

### DIFF
--- a/msgq/impl_zmq.cc
+++ b/msgq/impl_zmq.cc
@@ -7,10 +7,19 @@
 
 #include "msgq/impl_zmq.h"
 
+static size_t fnv1a_hash(const std::string &str) {
+    const size_t fnv_prime = 0x100000001b3;
+    size_t hash_value = 0xcbf29ce484222325;
+    for (char c : str) {
+        hash_value ^= (unsigned char)c;
+        hash_value *= fnv_prime;
+    }
+    return hash_value;
+}
+
 //FIXME: This is a hack to get the port number from the socket name, might have collisions
 static int get_port(std::string endpoint) {
-    std::hash<std::string> hasher;
-    size_t hash_value = hasher(endpoint);
+    size_t hash_value = fnv1a_hash(endpoint);
     int start_port = 8023;
     int max_port = 65535;
     int port = start_port + (hash_value % (max_port - start_port));


### PR DESCRIPTION
resolve https://github.com/commaai/openpilot/issues/34031 :

>  the issue is caused by a port mismatch between the Mac and the device:
> 
>     Attempting to connect to zmq endpoint: tcp://172.16.0.20:60942
>     Expected port on the device: 63557
> 
> It seems the static int get_port(std::string endpoint) function returns different port values on macOS and Linux, likely due to platform differences in how std::hash behaves.

This pr fixes the issue where the `get_port` function returns different port values on macOS and Linux due to platform-specific behavior of `std::hash`. The mismatch in port values causes connection failures in ZMQ. The solution replaces` std::hash `with a custom FNV-1a hash function to ensure consistent port values across platforms, and reducing the risk of collisions.

