### PR TITLE
VisionIpc: fix exception if server is killed while client is getting streams

### DIFF
--- a/msgq/visionipc/visionipc_client.cc
+++ b/msgq/visionipc/visionipc_client.cc
@@ -122,7 +122,11 @@ std::set<VisionStreamType> VisionIpcClient::getAvailableStreams(const std::strin
 
   VisionStreamType available_streams[VISION_STREAM_MAX] = {};
   r = ipc_sendrecv_with_fds(false, socket_fd, &available_streams, sizeof(available_streams), nullptr, 0, nullptr);
-  assert((r >= 0) && (r % sizeof(VisionStreamType) == 0));
+  if (r < 0) {
+    close(socket_fd);
+    return {};
+  }
+  assert(r % sizeof(VisionStreamType) == 0);
   close(socket_fd);
   return std::set<VisionStreamType>(available_streams, available_streams + r / sizeof(VisionStreamType));
 }

--- a/msgq/visionipc/visionipc_client.cc
+++ b/msgq/visionipc/visionipc_client.cc
@@ -55,6 +55,13 @@ bool VisionIpcClient::connect(bool blocking){
   VisionBuf bufs[VISIONIPC_MAX_FDS];
   r = ipc_sendrecv_with_fds(false, socket_fd, &bufs, sizeof(bufs), fds, VISIONIPC_MAX_FDS, &num_buffers);
 
+  if (r < 0) {
+    // only expected error is server shutting down
+    assert(errno == ECONNRESET);
+    close(socket_fd);
+    return false;
+  }
+
   assert(num_buffers >= 0);
   assert(r == sizeof(VisionBuf) * num_buffers);
 
@@ -122,10 +129,14 @@ std::set<VisionStreamType> VisionIpcClient::getAvailableStreams(const std::strin
 
   VisionStreamType available_streams[VISION_STREAM_MAX] = {};
   r = ipc_sendrecv_with_fds(false, socket_fd, &available_streams, sizeof(available_streams), nullptr, 0, nullptr);
+
   if (r < 0) {
+    // only expected error is server shutting down
+    assert(errno == ECONNRESET);
     close(socket_fd);
     return {};
   }
+
   assert(r % sizeof(VisionStreamType) == 0);
   close(socket_fd);
   return std::set<VisionStreamType>(available_streams, available_streams + r / sizeof(VisionStreamType));

--- a/msgq/visionipc/visionipc_client.cc
+++ b/msgq/visionipc/visionipc_client.cc
@@ -54,7 +54,6 @@ bool VisionIpcClient::connect(bool blocking){
   int fds[VISIONIPC_MAX_FDS];
   VisionBuf bufs[VISIONIPC_MAX_FDS];
   r = ipc_sendrecv_with_fds(false, socket_fd, &bufs, sizeof(bufs), fds, VISIONIPC_MAX_FDS, &num_buffers);
-
   if (r < 0) {
     // only expected error is server shutting down
     assert(errno == ECONNRESET);
@@ -129,7 +128,6 @@ std::set<VisionStreamType> VisionIpcClient::getAvailableStreams(const std::strin
 
   VisionStreamType available_streams[VISION_STREAM_MAX] = {};
   r = ipc_sendrecv_with_fds(false, socket_fd, &available_streams, sizeof(available_streams), nullptr, 0, nullptr);
-
   if (r < 0) {
     // only expected error is server shutting down
     assert(errno == ECONNRESET);


### PR DESCRIPTION
Fixes a ui crash in openpilot when ignition is rapidly cycled from off to on to off. The first assertion always passes (due to timing?), but the second can sometimes return -1.

This return code comes from this line where the errno is always 104 (ECONNRESET):

https://github.com/commaai/msgq/blob/434ed2312c980b5504a4a75001d04c3ecbddf93f/msgq/visionipc/visionipc.cc#L92-L93