### PR TITLE
remove receive signal handler

### DIFF
--- a/msgq/ipc_pyx.pyx
+++ b/msgq/ipc_pyx.pyx
@@ -199,11 +199,6 @@ cdef class SubSocket:
     msg = self.socket.receive(non_blocking)
 
     if msg == NULL:
-      # If a blocking read returns no message check errno if SIGINT was caught in the C++ code
-      if errno.errno == errno.EINTR:
-        print("SIGINT received, exiting")
-        sys.exit(1)
-
       return None
     else:
       sz = msg.getSize()


### PR DESCRIPTION
The only difference when receiving a termination signal is this line not being ran, but the program would be exiting anyway if this is the case:

```
msgq_msg_close(&msg); // Free unused message on exit
```

With the handler, the polling is not interrupted, so we hang until the timeout is up. If this is set high, we can get stuck here on exit.