### PR TITLE
VisionIpcClient: release GIL when receiving buffer

### DIFF
--- a/msgq/visionipc/visionipc.pxd
+++ b/msgq/visionipc/visionipc.pxd
@@ -52,7 +52,7 @@ cdef extern from "msgq/visionipc/visionipc_client.h":
     int num_buffers
     VisionBuf buffers[1]
     VisionIpcClient(string, VisionStreamType, bool, void*, void*)
-    VisionBuf * recv(VisionIpcBufExtra *, int)
+    VisionBuf * recv(VisionIpcBufExtra *, int) nogil
     bool connect(bool)
     bool is_connected()
     @staticmethod

--- a/msgq/visionipc/visionipc_pyx.pyx
+++ b/msgq/visionipc/visionipc_pyx.pyx
@@ -144,7 +144,8 @@ cdef class VisionIpcClient:
     return self.extra.valid
 
   def recv(self, int timeout_ms=100):
-    buf = self.client.recv(&self.extra, timeout_ms)
+    with nogil:
+      buf = self.client.recv(&self.extra, timeout_ms)
     if not buf:
       return None
     return VisionBuf.create(buf)


### PR DESCRIPTION
This greatly improved performance in commaai/openpilot#35089