### PR TITLE
VisionIpcServer: avoid vector copy in get_buffer()

### DIFF
--- a/msgq/visionipc/visionipc_server.cc
+++ b/msgq/visionipc/visionipc_server.cc
@@ -163,7 +163,7 @@ void VisionIpcServer::listener(){
 VisionBuf * VisionIpcServer::get_buffer(VisionStreamType type, int idx){
   // Do we want to keep track if the buffer has been sent out yet and warn user?
   assert(buffers.count(type));
-  auto b = buffers[type];
+  const auto &b = buffers[type];
   if (idx < 0) {
     idx = cur_idx[type]++ % b.size();
   } else {


### PR DESCRIPTION
`get_buffer() ` was copying the entire buffers vector on every call:


`
auto b = buffers[type];  // Creates a full copy of vector<VisionBuf*>
`

This PR switches to a `const&` to avoid the copy, reducing overhead.