### PR TITLE
visionipc_pyx: safe VisionBuf life time via client owner reference

### DIFF
--- a/msgq/visionipc/visionipc_pyx.pxd
+++ b/msgq/visionipc/visionipc_pyx.pxd
@@ -10,6 +10,7 @@ cdef class CLContext:
 
 cdef class VisionBuf:
   cdef cppVisionBuf * buf
+  cdef object _owner
 
   @staticmethod
-  cdef create(cppVisionBuf*)
+  cdef create(cppVisionBuf*, object)


### PR DESCRIPTION
Fxes a lifetime issue where `VisionIpcClient` could be destroyed while Python still held `VisionBuf` objects, leading to use-after-free and crashes. each `VisionBuf` now stores an _owner reference to its client/server, ensuring the underlying C++ object stays alive until all buffers are released.