### PR TITLE
logger: replace SWAGLOG include hack with runtime logger API

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -7,6 +7,7 @@ gen_dir = Dir('gen')
 
 # Build msgq
 msgq_objects = env.SharedObject([
+  'msgq/logger/logger.cc',
   'msgq/ipc.cc',
   'msgq/event.cc',
   'msgq/impl_msgq.cc',

--- a/msgq/__init__.py
+++ b/msgq/__init__.py
@@ -1,6 +1,6 @@
 # must be built with scons
 from msgq.ipc_pyx import Context, Poller, SubSocket, PubSocket, SocketEventHandle, toggle_fake_events, \
-                                set_fake_prefix, get_fake_prefix, delete_fake_prefix, wait_for_one_event, set_logger as _set_ipc_logger
+                                set_fake_prefix, get_fake_prefix, delete_fake_prefix, wait_for_one_event, set_logger
 from msgq.ipc_pyx import MultiplePublishersError, IpcError
 
 from typing import Optional, List, Union
@@ -12,31 +12,11 @@ assert set_fake_prefix
 assert get_fake_prefix
 assert delete_fake_prefix
 assert wait_for_one_event
+assert set_logger
 
 NO_TRAVERSAL_LIMIT = 2**64-1
 
 context = Context()
-_logger_callback = None
-
-
-def _set_visionipc_logger_if_available(callback):
-  try:
-    from msgq.visionipc.visionipc_pyx import set_logger as _set_visionipc_logger
-  except (ImportError, AttributeError):
-    return
-  _set_visionipc_logger(callback)
-
-
-def _get_logger_callback():
-  return _logger_callback
-
-
-def set_logger(callback):
-  global _logger_callback
-  _logger_callback = callback
-
-  _set_ipc_logger(callback)
-  _set_visionipc_logger_if_available(callback)
 
 
 def fake_event_handle(endpoint: str, identifier: Optional[Union[str, bytes]] = None, override: bool = True, enable: bool = False) -> SocketEventHandle:

--- a/msgq/__init__.py
+++ b/msgq/__init__.py
@@ -1,6 +1,6 @@
 # must be built with scons
 from msgq.ipc_pyx import Context, Poller, SubSocket, PubSocket, SocketEventHandle, toggle_fake_events, \
-                                set_fake_prefix, get_fake_prefix, delete_fake_prefix, wait_for_one_event
+                                set_fake_prefix, get_fake_prefix, delete_fake_prefix, wait_for_one_event, set_logger as _set_ipc_logger
 from msgq.ipc_pyx import MultiplePublishersError, IpcError
 
 from typing import Optional, List, Union
@@ -16,6 +16,27 @@ assert wait_for_one_event
 NO_TRAVERSAL_LIMIT = 2**64-1
 
 context = Context()
+_logger_callback = None
+
+
+def _set_visionipc_logger_if_available(callback):
+  try:
+    from msgq.visionipc.visionipc_pyx import set_logger as _set_visionipc_logger
+  except (ImportError, AttributeError):
+    return
+  _set_visionipc_logger(callback)
+
+
+def _get_logger_callback():
+  return _logger_callback
+
+
+def set_logger(callback):
+  global _logger_callback
+  _logger_callback = callback
+
+  _set_ipc_logger(callback)
+  _set_visionipc_logger_if_available(callback)
 
 
 def fake_event_handle(endpoint: str, identifier: Optional[Union[str, bytes]] = None, override: bool = True, enable: bool = False) -> SocketEventHandle:

--- a/msgq/ipc_pyx.pyx
+++ b/msgq/ipc_pyx.pyx
@@ -17,6 +17,25 @@ from .ipc cimport Poller as cppPoller
 from .ipc cimport Message as cppMessage
 from .ipc cimport Event as cppEvent, SocketEventHandle as cppSocketEventHandle
 
+cdef extern from "msgq/logger/logger.h":
+  ctypedef void (*msgq_logger_callback_t)(int level, const char *file, int line, const char *msg) noexcept
+  void msgq_set_logger(msgq_logger_callback_t callback)
+
+
+cdef object py_logger_callback = None
+
+
+cdef void run_python_logger_callback(int level, const char *file, int line, const char *msg) noexcept with gil:
+  if py_logger_callback is None:
+    return
+
+  py_file = (<bytes>file).decode("utf-8", "replace") if file != NULL else ""
+  py_msg = (<bytes>msg).decode("utf-8", "replace") if msg != NULL else ""
+  try:
+    py_logger_callback(level, py_file, line, py_msg)
+  except Exception:
+    pass
+
 
 class IpcError(Exception):
   def __init__(self, endpoint=None):
@@ -27,6 +46,21 @@ class IpcError(Exception):
 
 class MultiplePublishersError(IpcError):
   pass
+
+
+def set_logger(callback):
+  global py_logger_callback
+
+  if callback is None:
+    py_logger_callback = None
+    msgq_set_logger(NULL)
+    return
+
+  if not callable(callback):
+    raise TypeError("logger callback must be callable")
+
+  py_logger_callback = callback
+  msgq_set_logger(run_python_logger_callback)
 
 
 def toggle_fake_events(bool enabled):

--- a/msgq/logger/logger.cc
+++ b/msgq/logger/logger.cc
@@ -1,0 +1,46 @@
+#include "msgq/logger/logger.h"
+
+#include <atomic>
+#include <cstdio>
+#include <string>
+
+namespace {
+
+void default_logger(int level, const char *file, int line, const char *msg) {
+  std::fprintf(stderr, "[msgq] %d %s:%d %s\n",
+               level,
+               file != nullptr ? file : "<unknown>",
+               line,
+               msg != nullptr ? msg : "");
+}
+
+std::atomic<msgq_logger_callback_t> logger_callback(default_logger);
+
+}  // namespace
+
+extern "C" void msgq_set_logger(msgq_logger_callback_t callback) {
+  logger_callback.store(callback != nullptr ? callback : default_logger, std::memory_order_release);
+}
+
+extern "C" void msgq_logv(int level, const char *file, int line, const char *fmt, va_list args) {
+  if (fmt == nullptr) return;
+
+  va_list args_copy;
+  va_copy(args_copy, args);
+  const int needed = std::vsnprintf(nullptr, 0, fmt, args_copy);
+  va_end(args_copy);
+  if (needed < 0) return;
+
+  std::string message(static_cast<size_t>(needed), '\0');
+  std::vsnprintf(message.data(), message.size() + 1, fmt, args);
+
+  msgq_logger_callback_t callback = logger_callback.load(std::memory_order_acquire);
+  callback(level, file, line, message.c_str());
+}
+
+extern "C" void msgq_log(int level, const char *file, int line, const char *fmt, ...) {
+  va_list args;
+  va_start(args, fmt);
+  msgq_logv(level, file, line, fmt, args);
+  va_end(args);
+}

--- a/msgq/logger/logger.h
+++ b/msgq/logger/logger.h
@@ -1,9 +1,6 @@
 #pragma once
 
-#ifdef SWAGLOG
-// cppcheck-suppress preprocessorErrorDirective
-#include SWAGLOG
-#else
+#include <stdarg.h>
 
 #define CLOUDLOG_DEBUG 10
 #define CLOUDLOG_INFO 20
@@ -11,11 +8,27 @@
 #define CLOUDLOG_ERROR 40
 #define CLOUDLOG_CRITICAL 50
 
-#define cloudlog(lvl, fmt, ...) printf(fmt "\n", ## __VA_ARGS__)
-
-#define LOGD(fmt, ...) cloudlog(CLOUDLOG_DEBUG, fmt, ## __VA_ARGS__)
-#define LOG(fmt, ...) cloudlog(CLOUDLOG_INFO, fmt, ## __VA_ARGS__)
-#define LOGW(fmt, ...) cloudlog(CLOUDLOG_WARNING, fmt, ## __VA_ARGS__)
-#define LOGE(fmt, ...) cloudlog(CLOUDLOG_ERROR, fmt, ## __VA_ARGS__)
-
+#ifdef __GNUC__
+#define MSGQ_LOG_CHECK_FMT(a, b) __attribute__ ((format (printf, a, b)))
+#else
+#define MSGQ_LOG_CHECK_FMT(a, b)
 #endif
+
+typedef void (*msgq_logger_callback_t)(int level, const char *file, int line, const char *msg);
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void msgq_set_logger(msgq_logger_callback_t callback);
+void msgq_logv(int level, const char *file, int line, const char *fmt, va_list args) MSGQ_LOG_CHECK_FMT(4, 0);
+void msgq_log(int level, const char *file, int line, const char *fmt, ...) MSGQ_LOG_CHECK_FMT(4, 5);
+
+#ifdef __cplusplus
+}
+#endif
+
+#define LOGD(fmt, ...) msgq_log(CLOUDLOG_DEBUG, __FILE__, __LINE__, fmt, ## __VA_ARGS__)
+#define LOG(fmt, ...) msgq_log(CLOUDLOG_INFO, __FILE__, __LINE__, fmt, ## __VA_ARGS__)
+#define LOGW(fmt, ...) msgq_log(CLOUDLOG_WARNING, __FILE__, __LINE__, fmt, ## __VA_ARGS__)
+#define LOGE(fmt, ...) msgq_log(CLOUDLOG_ERROR, __FILE__, __LINE__, fmt, ## __VA_ARGS__)

--- a/msgq/visionipc/__init__.py
+++ b/msgq/visionipc/__init__.py
@@ -1,6 +1,13 @@
-from msgq.visionipc.visionipc_pyx import VisionBuf, VisionIpcClient, VisionIpcServer, VisionStreamType, get_endpoint_name
+from msgq.visionipc.visionipc_pyx import VisionBuf, VisionIpcClient, VisionIpcServer, VisionStreamType, get_endpoint_name, set_logger
 assert VisionBuf
 assert VisionIpcClient
 assert VisionIpcServer
 assert VisionStreamType
 assert get_endpoint_name
+assert set_logger
+
+try:
+  import msgq
+  set_logger(msgq._get_logger_callback())
+except (AttributeError, ImportError):
+  pass

--- a/msgq/visionipc/__init__.py
+++ b/msgq/visionipc/__init__.py
@@ -5,9 +5,3 @@ assert VisionIpcServer
 assert VisionStreamType
 assert get_endpoint_name
 assert set_logger
-
-try:
-  import msgq
-  set_logger(msgq._get_logger_callback())
-except (AttributeError, ImportError):
-  pass

--- a/msgq/visionipc/tests/test_visionipc.py
+++ b/msgq/visionipc/tests/test_visionipc.py
@@ -1,7 +1,6 @@
 import random
 from typing import Optional
 import numpy as np
-import msgq
 from msgq.visionipc import VisionIpcServer, VisionIpcClient, VisionStreamType
 
 
@@ -99,19 +98,3 @@ class TestVisionIpc:
     assert recv_buf is None
     del self.client
     del self.server
-
-  def test_python_logger_callback(self):
-    logs = []
-
-    def capture_log(level, file, line, message):
-      logs.append((level, file, line, message))
-
-    msgq.set_logger(capture_log)
-    try:
-      self.setup_vipc("camerad_logger_test", VisionStreamType.VISION_STREAM_ROAD)
-      del self.client
-      del self.server
-    finally:
-      msgq.set_logger(None)
-
-    assert any("Starting listener for: camerad_logger_test" in entry[3] for entry in logs)

--- a/msgq/visionipc/tests/test_visionipc.py
+++ b/msgq/visionipc/tests/test_visionipc.py
@@ -1,6 +1,7 @@
 import random
 from typing import Optional
 import numpy as np
+import msgq
 from msgq.visionipc import VisionIpcServer, VisionIpcClient, VisionStreamType
 
 
@@ -98,3 +99,19 @@ class TestVisionIpc:
     assert recv_buf is None
     del self.client
     del self.server
+
+  def test_python_logger_callback(self):
+    logs = []
+
+    def capture_log(level, file, line, message):
+      logs.append((level, file, line, message))
+
+    msgq.set_logger(capture_log)
+    try:
+      self.setup_vipc("camerad_logger_test", VisionStreamType.VISION_STREAM_ROAD)
+      del self.client
+      del self.server
+    finally:
+      msgq.set_logger(None)
+
+    assert any("Starting listener for: camerad_logger_test" in entry[3] for entry in logs)

--- a/msgq/visionipc/visionipc.pxd
+++ b/msgq/visionipc/visionipc.pxd
@@ -45,8 +45,8 @@ cdef extern from "msgq/visionipc/visionipc_client.h":
     int num_buffers
     VisionBuf buffers[1]
     VisionIpcClient(string, VisionStreamType, bool)
-    VisionBuf * recv(VisionIpcBufExtra *, int)
-    bool connect(bool)
+    VisionBuf * recv(VisionIpcBufExtra *, int) nogil
+    bool connect(bool) nogil
     bool is_connected()
     @staticmethod
     set[VisionStreamType] getAvailableStreams(string, bool)

--- a/msgq/visionipc/visionipc_pyx.pyx
+++ b/msgq/visionipc/visionipc_pyx.pyx
@@ -16,6 +16,40 @@ from .visionipc cimport VisionBuf as cppVisionBuf
 from .visionipc cimport VisionIpcBufExtra
 from .visionipc cimport get_endpoint_name as cpp_get_endpoint_name
 
+cdef extern from "msgq/logger/logger.h":
+  ctypedef void (*msgq_logger_callback_t)(int level, const char *file, int line, const char *msg) noexcept
+  void msgq_set_logger(msgq_logger_callback_t callback)
+
+
+cdef object py_logger_callback = None
+
+
+cdef void run_python_logger_callback(int level, const char *file, int line, const char *msg) noexcept with gil:
+  if py_logger_callback is None:
+    return
+
+  py_file = (<bytes>file).decode("utf-8", "replace") if file != NULL else ""
+  py_msg = (<bytes>msg).decode("utf-8", "replace") if msg != NULL else ""
+  try:
+    py_logger_callback(level, py_file, line, py_msg)
+  except Exception:
+    pass
+
+
+def set_logger(callback):
+  global py_logger_callback
+
+  if callback is None:
+    py_logger_callback = None
+    msgq_set_logger(NULL)
+    return
+
+  if not callable(callback):
+    raise TypeError("logger callback must be callable")
+
+  py_logger_callback = callback
+  msgq_set_logger(run_python_logger_callback)
+
 
 def get_endpoint_name(string name, VisionStreamType stream):
   return cpp_get_endpoint_name(name, stream).decode('utf-8')
@@ -95,7 +129,9 @@ cdef class VisionIpcServer:
     self.server.start_listener()
 
   def __dealloc__(self):
-    del self.server
+    if self.server != NULL:
+      with nogil:
+        del self.server
 
 
 cdef class VisionIpcClient:
@@ -106,7 +142,9 @@ cdef class VisionIpcClient:
     self.client = new cppVisionIpcClient(name, stream, conflate)
 
   def __dealloc__(self):
-    del self.client
+    if self.client != NULL:
+      with nogil:
+        del self.client
 
   @property
   def width(self):
@@ -149,13 +187,18 @@ cdef class VisionIpcClient:
     return self.extra.valid
 
   def recv(self, int timeout_ms=100):
-    buf = self.client.recv(&self.extra, timeout_ms)
+    cdef cppVisionBuf * buf
+    with nogil:
+      buf = self.client.recv(&self.extra, timeout_ms)
     if not buf:
       return None
     return VisionBuf.create(buf)
 
   def connect(self, bool blocking):
-    return self.client.connect(blocking)
+    cdef bool connected
+    with nogil:
+      connected = self.client.connect(blocking)
+    return connected
 
   def is_connected(self):
     return self.client.is_connected()


### PR DESCRIPTION
## Summary
- replace the `SWAGLOG` compile-time include hook with a runtime logger API in `msgq/logger/logger.h`
- add `msgq_set_logger()` and `msgq_log()` implementation in new `msgq/logger/logger.cc`
- expose Python-side logger registration in both `ipc_pyx` and `visionipc_pyx`
- release the GIL around blocking `VisionIpcClient.connect/recv` and C++ object destruction to avoid callback deadlocks

## Validation
- `scons -j8 --minimal`
- `PYTHONPATH=. pytest -q msgq/tests/test_messaging.py msgq/tests/test_poller.py msgq/visionipc/tests/test_visionipc.py`
