### PR TITLE
msgq: bump max readers to 25

### DIFF
--- a/msgq/msgq.h
+++ b/msgq/msgq.h
@@ -6,7 +6,7 @@
 #include <atomic>
 
 #define DEFAULT_SEGMENT_SIZE (1 * 1024 * 1024)
-#define NUM_READERS 15
+#define NUM_READERS 25
 #define ALIGN(n) ((n + (8 - 1)) & -8)
 
 #define UNUSED(x) (void)x


### PR DESCRIPTION
In openpilot, with the new `lateral_maneuversd` tool introduced in https://github.com/commaai/openpilot/pull/37562, `carState` reaches exactly 15 readers, which is the hard cap defined by `NUM_READERS` currently.

Bumping this to 25 allows headroom for future proofing.