### PR TITLE
fix native wheel platform tag

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,10 @@ classifiers = [
 ]
 dependencies = []
 
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
 [project.optional-dependencies]
 dev = [
   "setuptools",  # for distutils

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,11 @@
+from setuptools import Distribution, setup
+
+
+class BinaryDistribution(Distribution):
+  """Mark wheels containing the pre-built Cython modules as platform-specific."""
+
+  def has_ext_modules(self) -> bool:
+    return True
+
+
+setup(distclass=BinaryDistribution)

--- a/test.sh
+++ b/test.sh
@@ -12,7 +12,7 @@ scons -j8
 # Verify the package is installable and is not mislabeled as platform-independent.
 rm -rf dist
 uv build --wheel
-wheel="$(find dist -maxdepth 1 -name '*.whl' -print -quit)"
+wheel="$(realpath "$(find dist -maxdepth 1 -name '*.whl' -print -quit)")"
 if [[ "$wheel" == *-none-any.whl ]]; then
   echo "native extension wheel is incorrectly tagged as platform-independent: $wheel" >&2
   exit 1

--- a/test.sh
+++ b/test.sh
@@ -9,6 +9,17 @@ source ./setup.sh
 # *** build ***
 scons -j8
 
+# Verify the package is installable and is not mislabeled as platform-independent.
+rm -rf dist
+uv build --wheel
+wheel="$(find dist -maxdepth 1 -name '*.whl' -print -quit)"
+if [[ "$wheel" == *-none-any.whl ]]; then
+  echo "native extension wheel is incorrectly tagged as platform-independent: $wheel" >&2
+  exit 1
+fi
+uv run --isolated --no-project --with "$wheel" --directory / python -c \
+  "import msgq, msgq.visionipc"
+
 # *** lint + test ***
 lefthook run test
 


### PR DESCRIPTION
## Summary

- declare setuptools as the PEP 517 build backend
- mark the distribution as containing native extensions so wheels receive a platform-specific tag
- build and install the wheel in CI, including an explicit guard against `none-any` wheels

## Why

msgq packages pre-built Cython shared objects. Without telling setuptools that the distribution contains native extensions, the generated wheel can be tagged as platform-independent even though its binaries only work on the OS and architecture that built them.

## Test plan

- `pip wheel . --no-deps --no-build-isolation` produces `msgq-0.0.1-cp312-cp312-win_amd64.whl`
- `bash -n test.sh setup.sh`
- `git diff --check`
- CI builds and imports the installed wheel on Ubuntu and macOS

Related to #619.
